### PR TITLE
Added dirt bonemealing

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalEvents.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalEvents.java
@@ -203,8 +203,10 @@ public class EnvironmentalEvents {
 				}
 			}
 			if (!potentialStates.isEmpty()) {
-				world.setBlockState(pos, potentialStates.get(world.getRandom().nextInt(potentialStates.size())), 3);
-				if (!world.isRemote()) world.playEvent(2005, pos, 0);
+				if (!world.isRemote()) {
+					world.playEvent(2005, pos, 0);
+					world.setBlockState(pos, potentialStates.get(world.getRandom().nextInt(potentialStates.size())), 3);
+				}
 				if (!player.isCreative()) stack.shrink(1);
 				event.setCancellationResult(ActionResultType.func_233537_a_(world.isRemote()));
 				event.setCanceled(true);

--- a/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalEvents.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalEvents.java
@@ -194,7 +194,7 @@ public class EnvironmentalEvents {
 		PlayerEntity player = event.getPlayer();
 		ItemStack stack = event.getItemStack();
 		Item item = stack.getItem();
-		if (item == Items.BONE_MEAL && state.getBlock() == Blocks.DIRT) {
+		if (item == Items.BONE_MEAL && state.getBlock() == Blocks.DIRT && world.getBlockState(pos.up()).propagatesSkylightDown(world, pos)) {
 			ArrayList<BlockState> potentialStates = new ArrayList<>();
 			for (BlockPos blockpos : BlockPos.getAllInBoxMutable(pos.add(-1, -1, -1), pos.add(1, 1, 1))) {
 				Block block = world.getBlockState(blockpos).getBlock();


### PR DESCRIPTION
I think this feature was mentioned a while ago, essentially it's netherrack bonemealing for dirt spreadables like grass and mycelium (I considered adding support for podzol but it's not a growing thing and already has a renewing mechanic). It should be possible to make it compatible with other mods by using `ForgeRegistries.BLOCKS.getValue()` in the dirt spreadables list, but I don't know if anything needs that yet apart from possibly crustose.