### PR TITLE
Converted to addToJigsawPattern for adding to village pools

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/core/registry/EnvironmentalVillagers.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/registry/EnvironmentalVillagers.java
@@ -1,9 +1,8 @@
 package com.minecraftabnormals.environmental.core.registry;
 
 import com.google.common.collect.ImmutableSet;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.environmental.core.Environmental;
-import com.mojang.datafixers.util.Either;
-import com.mojang.datafixers.util.Pair;
 import net.minecraft.entity.ai.brain.task.GiveHeroGiftsTask;
 import net.minecraft.entity.merchant.villager.VillagerProfession;
 import net.minecraft.entity.merchant.villager.VillagerTrades;
@@ -11,16 +10,12 @@ import net.minecraft.entity.villager.VillagerType;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvents;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.WorldGenRegistries;
 import net.minecraft.village.PointOfInterestType;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
-import net.minecraft.world.gen.feature.jigsaw.LegacySingleJigsawPiece;
 import net.minecraft.world.gen.feature.structure.*;
-import net.minecraft.world.gen.feature.template.ProcessorLists;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
@@ -96,16 +91,6 @@ public class EnvironmentalVillagers {
 	}
 
 	private static void addVillagerHouse(String type, String biome, int weight) {
-		addToPool(new ResourceLocation("village/" + biome + "/houses"), new ResourceLocation(Environmental.MOD_ID, "village/" + type + "_house_" + biome + "_1"), 5);
-	}
-
-	private static void addToPool(ResourceLocation pool, ResourceLocation toAdd, int weight) {
-		JigsawPattern old = WorldGenRegistries.JIGSAW_POOL.getOrDefault(pool);
-		List<JigsawPiece> shuffled = old.getShuffledPieces(new Random());
-		List<Pair<JigsawPiece, Integer>> newPieces = new ArrayList<>();
-		for (JigsawPiece p : shuffled) newPieces.add(new Pair<>(p, 1));
-		newPieces.add(Pair.of(new LegacySingleJigsawPiece(Either.left(toAdd), () -> ProcessorLists.field_244101_a, JigsawPattern.PlacementBehaviour.RIGID), weight));
-		ResourceLocation name = old.getName();
-		Registry.register(WorldGenRegistries.JIGSAW_POOL, pool, new JigsawPattern(pool, name, newPieces));
+		DataUtil.addToJigsawPattern(new ResourceLocation("village/" + biome + "/houses"), JigsawPiece.func_242859_b(Environmental.MOD_ID + ":village/" + type + "_house_" + biome + "_1").apply(JigsawPattern.PlacementBehaviour.RIGID), weight);
 	}
 }


### PR DESCRIPTION
The previous method of adding to pools wasn't ideal as it set all of the vanilla village house weights to 1. This PR changes it to use AC's `addToJigsawPattern` instead, which doesn't do this.