### PR TITLE
make pouches spawn in modded structures too

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/core/Environmental.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/Environmental.java
@@ -8,6 +8,7 @@ import com.minecraftabnormals.environmental.common.slabfish.condition.SlabfishCo
 import com.minecraftabnormals.environmental.core.other.EnvironmentalCompat;
 import com.minecraftabnormals.environmental.core.other.EnvironmentalDataProcessors;
 import com.minecraftabnormals.environmental.core.other.EnvironmentalDataSerializers;
+import com.minecraftabnormals.environmental.core.other.EnvironmentalPouchEquipping;
 import com.minecraftabnormals.environmental.core.registry.*;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.inventory.container.PlayerContainer;
@@ -89,6 +90,7 @@ public class Environmental {
 
 	private void setupCommon(final FMLCommonSetupEvent event) {
 		event.enqueueWork(() -> {
+			EnvironmentalPouchEquipping.setupPouchStructures();
 			EnvironmentalCompat.registerCompat();
 			EnvironmentalEntities.registerSpawns();
 			EnvironmentalBiomes.addBiomeTypes();

--- a/src/main/java/com/minecraftabnormals/environmental/core/mixin/MobEntityMixin.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/mixin/MobEntityMixin.java
@@ -1,18 +1,13 @@
 package com.minecraftabnormals.environmental.core.mixin;
 
-import com.minecraftabnormals.environmental.core.registry.EnvironmentalItems;
+import com.minecraftabnormals.environmental.core.other.EnvironmentalPouchEquipping;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MobEntity;
-import net.minecraft.inventory.EquipmentSlotType;
-import net.minecraft.item.ItemStack;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.World;
-import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.server.ServerWorld;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -20,25 +15,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(MobEntity.class)
 public abstract class MobEntityMixin extends LivingEntity {
 
-	@Shadow
-	@Final
-	protected float[] armorDropChances;
-
 	protected MobEntityMixin(EntityType<? extends LivingEntity> type, World worldIn) {
 		super(type, worldIn);
 	}
 
 	@Inject(method = "populateDefaultEquipmentSlots", at = @At("TAIL"))
 	private void setEquipmentBasedOnDifficulty(DifficultyInstance difficulty, CallbackInfo info) {
-		int difficultyChance = difficulty.getDifficulty().getId() + 1;
 		if (this.getCommandSenderWorld() instanceof ServerWorld) {
-			ServerWorld world = (ServerWorld) this.getCommandSenderWorld();
-			boolean isStronghold = world.structureFeatureManager().getStructureAt(this.blockPosition(), true, Structure.STRONGHOLD).isValid();
-			boolean isMineshaft = world.structureFeatureManager().getStructureAt(this.blockPosition(), true, Structure.MINESHAFT).isValid();
-			if ((isStronghold || isMineshaft) && Math.random() < difficultyChance * 0.01F) {
-				this.setItemSlot(EquipmentSlotType.CHEST, new ItemStack(EnvironmentalItems.HEALER_POUCH.get()));
-				this.armorDropChances[EquipmentSlotType.CHEST.getIndex()] = 1.0F;
-			}
+			int difficultyChance = difficulty.getDifficulty().getId() + 1;
+			EnvironmentalPouchEquipping.equipPouch((ServerWorld) this.getCommandSenderWorld(), (MobEntity) (Object) this, difficultyChance);
 		}
 	}
 }

--- a/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalPouchEquipping.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalPouchEquipping.java
@@ -1,0 +1,69 @@
+package com.minecraftabnormals.environmental.core.other;
+
+import com.minecraftabnormals.environmental.core.registry.EnvironmentalItems;
+import net.minecraft.entity.MobEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.gen.feature.structure.Structure;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EnvironmentalPouchEquipping {
+
+    private static final List<Structure<?>> STRUCTURES_FOR_POUCHES = new ArrayList<>();
+
+    public static void setupPouchStructures(){
+        STRUCTURES_FOR_POUCHES.add(Structure.MINESHAFT);
+        STRUCTURES_FOR_POUCHES.add(Structure.STRONGHOLD);
+
+        if (ModList.get().isLoaded("betterstrongholds")) {
+            STRUCTURES_FOR_POUCHES.add(getStructure("betterstrongholds", "stronghold"));
+        }
+
+        if (ModList.get().isLoaded("bettermineshafts")) {
+            STRUCTURES_FOR_POUCHES.add(getStructure("bettermineshafts", "mineshaft"));
+        }
+
+        if (ModList.get().isLoaded("endrem")) {
+            STRUCTURES_FOR_POUCHES.add(getStructure("endrem", "end_castle"));
+        }
+
+        if (ModList.get().isLoaded("repurposed_structures")) {
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_birch"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_dark_forest"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_desert"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_end"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_nether"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_crimson"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_warped"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_icy"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_jungle"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_ocean"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_savanna"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_stone"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_swamp"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_taiga"));
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "stronghold_nether"));
+
+            // Mistake on RS's end. Will be fixed next RS update
+            STRUCTURES_FOR_POUCHES.add(getStructure("repurposed_structures", "mineshaft_swamp_forest"));
+        }
+    }
+
+    private static Structure<?> getStructure(String modid, String structureid){
+        return ForgeRegistries.STRUCTURE_FEATURES.getValue(new ResourceLocation(modid, structureid));
+    }
+
+    public static void equipPouch(ServerWorld world, MobEntity mobEntity, int difficultyChance){
+        boolean validPouchStructure = STRUCTURES_FOR_POUCHES.stream().anyMatch(structure -> world.structureFeatureManager().getStructureAt(mobEntity.blockPosition(), true, structure).isValid());
+        if (validPouchStructure && Math.random() < difficultyChance * 0.01F) {
+            mobEntity.setItemSlot(EquipmentSlotType.CHEST, new ItemStack(EnvironmentalItems.HEALER_POUCH.get()));
+            mobEntity.setDropChance(EquipmentSlotType.CHEST, 1.0F);
+        }
+    }
+}


### PR DESCRIPTION
here's a small change with the pouch spawning. Now at mod startup, environmental will add vanilla mineshaft and stronghold to a list. Then check if each mod is on and if so, add their stronghold structures/replacements or mineshafts to the list as well. And when mobs are spawning, it will check all structures in the list to see if they are within any of the structure's bounds.

You can even hook up a config to this to let people change what structures can spawn pouch mobs as well! This is technically *slightly* more efficient when it is just environmental on as if a mob is in a mineshaft, it will set the boolean to true right away and not also check the stronghold since there's no need to anymore.

Hope this helps!