### PR TITLE
Register Environmental config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/core/Environmental.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/Environmental.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.environmental.core;
 
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.environmental.client.render.SlabfishSpriteUploader;
 import com.minecraftabnormals.environmental.common.network.message.*;
@@ -85,6 +86,7 @@ public class Environmental {
 		});
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, EnvironmentalConfig.COMMON_SPEC);
+		DataUtil.registerConfigCondition(Environmental.MOD_ID, EnvironmentalConfig.COMMON);
 	}
 
 	private void setupCommon(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/minecraftabnormals/environmental/core/EnvironmentalConfig.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/EnvironmentalConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.environmental.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -9,26 +10,60 @@ import org.apache.commons.lang3.tuple.Pair;
 public class EnvironmentalConfig {
 
 	public static class Common {
+
+		@ConfigKey("generate_giant_mushrooms")
 		public final ConfigValue<Boolean> generateGiantMushrooms;
+
+		@ConfigKey("generate_giant_tall_grass")
 		public final ConfigValue<Boolean> generateGiantTallGrass;
+
+		@ConfigKey("generate_wisteria_trees")
 		public final ConfigValue<Boolean> generateWisteriaTrees;
+
+		@ConfigKey("generate_delphiniums")
 		public final ConfigValue<Boolean> generateDelphiniums;
+
+		@ConfigKey("generate_hibiscus")
 		public final ConfigValue<Boolean> generateHibiscus;
 
+
+		@ConfigKey("marsh_weight")
 		public final ConfigValue<Integer> marshWeight;
+
+		@ConfigKey("mushroom_marsh_weight")
 		public final ConfigValue<Integer> mushroomMarshWeight;
 
+
+		@ConfigKey("blossom_woods_weight")
 		public final ConfigValue<Integer> blossomWoodsWeight;
+
+		@ConfigKey("blossom_hills_weight")
 		public final ConfigValue<Integer> blossomHillsWeight;
+
+		@ConfigKey("blossom_highlands_weight")
 		public final ConfigValue<Integer> blossomHighlandsWeight;
+
+		@ConfigKey("blossom_valleys_weight")
 		public final ConfigValue<Integer> blossomValleysWeight;
 
+
+		@ConfigKey("limit_farm_animal_spawns")
 		public final ConfigValue<Boolean> limitFarmAnimalSpawns;
+
+		@ConfigKey("biome_variants_always_spawn")
 		public final ConfigValue<Boolean> biomeVariantsAlwaysSpawn;
 
+
+		@ConfigKey("koi_only_block_natural_spawns")
 		public final ConfigValue<Boolean> blockOnlyNaturalSpawns;
+
+		@ConfigKey("koi_horizontal_serenity_range")
 		public final ConfigValue<Integer> koiHorizontalSerenityRange;
+
+		@ConfigKey("koi_vertical_serenity_range")
 		public final ConfigValue<Integer> koiVerticalSerenityRange;
+
+		@ConfigKey("koi_give_serenity")
 		public final ConfigValue<Boolean> serenityEffect;
 
 		Common(ForgeConfigSpec.Builder builder) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.