### PR TITLE
Fixes a NullPointerException

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalEvents.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/other/EnvironmentalEvents.java
@@ -177,7 +177,7 @@ public class EnvironmentalEvents {
 
 		if (projectileEntity instanceof ProjectileItemEntity) {
 			ProjectileItemEntity projectileitem = (ProjectileItemEntity) projectileEntity;
-			if (event.getRayTraceResult().getType() == RayTraceResult.Type.ENTITY) {
+			if (event.getRayTraceResult() != null && event.getRayTraceResult().getType() == RayTraceResult.Type.ENTITY) {
 				EntityRayTraceResult entity = (EntityRayTraceResult) event.getRayTraceResult();
 				if (entity.getEntity() instanceof SlabfishEntity) {
 					SlabfishEntity slabfish = (SlabfishEntity) entity.getEntity();


### PR DESCRIPTION
```java
[20:38:36] [Server thread/ERROR] [ne.mi.ev.EventBus/EVENTBUS]: Exception caught during firing event: null
        Index: 1
        Listeners:
                0: NORMAL
                1: ASM: class com.minecraftabnormals.environmental.core.other.EnvironmentalEvents onProjectileImpact(Lnet/minecraftforge/event/entity/ProjectileImpactEvent$Throwable;)V
                2: ASM: class com.lilypuree.decorative_blocks.setup.ModSetup onProjectileCollisionEvent(Lnet/minecraftforge/event/entity/ProjectileImpactEvent$Throwable;)V
                3: ASM: class com.simibubi.create.content.contraptions.processing.burner.BlazeBurnerHandler onThrowableImpact(Lnet/minecraftforge/event/entity/ProjectileImpactEvent$Throwable;)V
                4: ASM: com.github.alexthe666.alexsmobs.event.ServerEvents@181411ed onProjectileHit(Lnet/minecraftforge/event/entity/ProjectileImpactEvent;)V
                5: ASM: Block{naturesaura:projectile_generator} onProjectileImpact(Lnet/minecraftforge/event/entity/ProjectileImpactEvent;)V
java.lang.NullPointerException
        at com.minecraftabnormals.environmental.core.other.EnvironmentalEvents.onProjectileImpact(EnvironmentalEvents.java:180)
        at net.minecraftforge.eventbus.ASMEventHandler_1210_EnvironmentalEvents_onProjectileImpact_Throwable.invoke(.dynamic)
        at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85)
        at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302)
        at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283)
        at net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(ForgeEventFactory.java:663)
        at net.mehvahdjukaar.supplementaries.entities.ImprovedProjectileEntity.func_70071_h_(ImprovedProjectileEntity.java:214)
```