### PR TITLE
added block update to placement of wisteria leaf blocks 

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/common/world/gen/util/WisteriaTreeUtils.java
+++ b/src/main/java/com/minecraftabnormals/environmental/common/world/gen/util/WisteriaTreeUtils.java
@@ -98,7 +98,7 @@ public class WisteriaTreeUtils {
 	}
 
 	public static void setForcedState(IWorldWriter worldIn, BlockPos pos, BlockState state) {
-		worldIn.setBlock(pos, state, 18);
+		worldIn.setBlock(pos, state, 19);
 	}
 
 	public static void setDirtAt(IWorld worldIn, BlockPos pos) {


### PR DESCRIPTION
Hey, I've been privately tinkering with the Wisteria tree gen to figure out why it sometimes has odd behaviour with other mods. I identified the fix and wanted to give you the heads up! 

Found out it is due to the way the copy of setForcedState() in WisteriaTreeUtils places leaf blocks.

Leaf blocks need a block update upon generation so that updateDistance() can be calculated. Otherwise, all leaves are generated with a distance of 1 and this breaks most DFS algo's used in other mods (e.g., Create Mod's sawmill).