### PR TITLE
Add config option for truffle vitality potions

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/core/EnvironmentalConfig.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/EnvironmentalConfig.java
@@ -30,6 +30,7 @@ public class EnvironmentalConfig {
 		public final ConfigValue<Boolean> biomeVariantsAlwaysSpawn;
 
 		public final ConfigValue<List<String>> healerPouchStructures;
+		public final ConfigValue<Boolean> truffleVitalityPotion;
 
 		public final ConfigValue<Boolean> blockOnlyNaturalSpawns;
 		public final ConfigValue<Integer> koiHorizontalSerenityRange;
@@ -62,6 +63,9 @@ public class EnvironmentalConfig {
 			builder.push("items");
 			builder.push("healers_pouch");
 			healerPouchStructures = builder.comment("Structures that can spawn mobs wearing a Healer's Pouch").define("Healer's Pouch structures", Lists.newArrayList("minecraft:mineshaft", "minecraft:stronghold"));
+			builder.pop();
+			builder.push("truffle_vitality_potion");
+			truffleVitalityPotion = builder.comment("Enable using truffles to brew potions of vitality (health boost)").define("Truffle Vitality Potions", true);
 			builder.pop();
 			builder.pop();
 

--- a/src/main/java/com/minecraftabnormals/environmental/core/registry/EnvironmentalEffects.java
+++ b/src/main/java/com/minecraftabnormals/environmental/core/registry/EnvironmentalEffects.java
@@ -3,6 +3,7 @@ package com.minecraftabnormals.environmental.core.registry;
 import com.minecraftabnormals.abnormals_core.common.potion.AbnormalsEffect;
 import com.minecraftabnormals.environmental.common.potion.PanicEffect;
 import com.minecraftabnormals.environmental.core.Environmental;
+import com.minecraftabnormals.environmental.core.EnvironmentalConfig;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.item.Items;
@@ -24,7 +25,9 @@ public class EnvironmentalEffects {
 	public static final RegistryObject<Potion> VITALITY_STRONG = POTIONS.register("vitality_strong", () -> new Potion(new EffectInstance(Effects.HEALTH_BOOST, 4800, 1)));
 
 	public static void registerBrewingRecipes() {
-		PotionBrewing.addMix(Potions.AWKWARD, EnvironmentalItems.TRUFFLE.get(), VITALITY.get());
-		PotionBrewing.addMix(VITALITY.get(), Items.GLOWSTONE_DUST, VITALITY_STRONG.get());
+		if (EnvironmentalConfig.COMMON.truffleVitalityPotion.get()) {
+			PotionBrewing.addMix(Potions.AWKWARD, EnvironmentalItems.TRUFFLE.get(), VITALITY.get());
+			PotionBrewing.addMix(VITALITY.get(), Items.GLOWSTONE_DUST, VITALITY_STRONG.get());
+		}
 	}
 }


### PR DESCRIPTION
This pull request introduces a configuration choice that allows for the deactivation of the brewing of truffle-based vitality potions, which is enabled by default.

![image](https://user-images.githubusercontent.com/42828197/225396553-4d694ffa-02f3-4d62-944f-a67464ae2e99.png)

Why? I run a modpack server with another mod that introduces its own health boost at waaaaay higher cost, and I don't want it to be obsolete.

The code change is minimal, there will be no impact on players who don't know or care about this, and as only the registration of the brewing mix is canceled, the potions still appear in creative and other mods could assign different brewing mixes to it.