### PR TITLE
Two mild bugfixes

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/stripped_logs.json
+++ b/src/generated/resources/data/forge/tags/blocks/stripped_logs.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "environmental:stripped_willow_log",
+    "environmental:stripped_pine_log",
+    "environmental:stripped_wisteria_log",
+    "environmental:stripped_plum_log"
+  ]
+}

--- a/src/main/java/com/teamabnormals/environmental/common/block/PottedCartwheelBlock.java
+++ b/src/main/java/com/teamabnormals/environmental/common/block/PottedCartwheelBlock.java
@@ -1,19 +1,28 @@
 package com.teamabnormals.environmental.common.block;
 
+import com.teamabnormals.environmental.core.Environmental;
+import com.teamabnormals.environmental.core.registry.EnvironmentalBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.stats.Stats;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.FlowerPotBlock;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
 
+@Mod.EventBusSubscriber(modid = Environmental.MOD_ID)
 public class PottedCartwheelBlock extends FlowerPotBlock {
 	public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
 
@@ -40,5 +49,23 @@ public class PottedCartwheelBlock extends FlowerPotBlock {
 	@Override
 	protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
 		builder.add(FACING);
+	}
+
+	@SubscribeEvent
+	public static void interact(PlayerInteractEvent.RightClickBlock event) {
+		Level level = event.getLevel();
+		ItemStack stack = event.getItemStack();
+		BlockPos pos = event.getPos();
+		if (level.getBlockState(pos).getBlock() == Blocks.FLOWER_POT && stack.getItem() == EnvironmentalBlocks.CARTWHEEL.get().asItem()) {
+			System.out.println(event.getEntity().getDirection().getOpposite());
+			level.setBlock(pos, EnvironmentalBlocks.POTTED_CARTWHEEL.get().defaultBlockState().setValue(FACING, event.getEntity().getDirection().getOpposite()), 0);
+			event.getEntity().awardStat(Stats.POT_FLOWER);
+			if (!event.getEntity().getAbilities().instabuild) {
+				stack.shrink(1);
+			}
+			event.setUseBlock(Event.Result.DENY);
+			event.setCancellationResult(InteractionResult.SUCCESS);
+			event.setCanceled(true);
+		}
 	}
 }

--- a/src/main/java/com/teamabnormals/environmental/common/block/WaxedPineconeBlock.java
+++ b/src/main/java/com/teamabnormals/environmental/common/block/WaxedPineconeBlock.java
@@ -24,7 +24,6 @@ public class WaxedPineconeBlock extends Block {
 			Level level = context.getLevel();
 			Player player = context.getPlayer();
 			BlockPos pos = context.getClickedPos();
-			level.playSound(player, pos, SoundEvents.AXE_STRIP, SoundSource.BLOCKS, 1.0F, 1.0F);
 			level.levelEvent(player, 3004, pos, 0);
 			return EnvironmentalBlocks.PINECONE.get().defaultBlockState();
 		}

--- a/src/main/java/com/teamabnormals/environmental/core/data/server/tags/EnvironmentalBlockTagsProvider.java
+++ b/src/main/java/com/teamabnormals/environmental/core/data/server/tags/EnvironmentalBlockTagsProvider.java
@@ -118,5 +118,7 @@ public class EnvironmentalBlockTagsProvider extends BlockTagsProvider {
 		this.tag(BlueprintBlockTags.LEAF_PILES).add(WILLOW_LEAF_PILE.get(), PINE_LEAF_PILE.get(), WISTERIA_LEAF_PILE.get(), PINK_WISTERIA_LEAF_PILE.get(), BLUE_WISTERIA_LEAF_PILE.get(), PURPLE_WISTERIA_LEAF_PILE.get(), WHITE_WISTERIA_LEAF_PILE.get(), PLUM_LEAF_PILE.get(), CHEERFUL_PLUM_LEAF_PILE.get(), MOODY_PLUM_LEAF_PILE.get(), HIBISCUS_LEAF_PILE.get());
 
 		this.tag(Tags.Blocks.FENCE_GATES_WOODEN).add(WILLOW_FENCE_GATE.get(), PINE_FENCE_GATE.get(), WISTERIA_FENCE_GATE.get(), PLUM_FENCE_GATE.get());
+
+		this.tag(STRIPPED_LOGS).add(STRIPPED_WILLOW_LOG.get(), STRIPPED_PINE_LOG.get(), STRIPPED_WISTERIA_LOG.get(), STRIPPED_PLUM_LOG.get());
 	}
 }

--- a/src/main/java/com/teamabnormals/environmental/core/other/tags/EnvironmentalBlockTags.java
+++ b/src/main/java/com/teamabnormals/environmental/core/other/tags/EnvironmentalBlockTags.java
@@ -23,6 +23,8 @@ public class EnvironmentalBlockTags {
 	public static final TagKey<Block> WISTERIA_LOGS = blockTag("wisteria_logs");
 	public static final TagKey<Block> PLUM_LOGS = blockTag("plum_logs");
 
+	public static final TagKey<Block> STRIPPED_LOGS = TagUtil.blockTag("forge", "stripped_logs");
+
 	private static TagKey<Block> blockTag(String tagName) {
 		return TagUtil.blockTag(Environmental.MOD_ID, tagName);
 	}

--- a/src/main/resources/assets/environmental/blockstates/potted_cartwheel.json
+++ b/src/main/resources/assets/environmental/blockstates/potted_cartwheel.json
@@ -1,5 +1,8 @@
 {
     "variants": {
-        "": { "model": "environmental:block/potted_cartwheel" }
+        "facing=north": { "model": "environmental:block/potted_cartwheel" },
+        "facing=east": { "model": "environmental:block/potted_cartwheel", "y": 90 },
+        "facing=south": { "model": "environmental:block/potted_cartwheel", "y": 180 },
+        "facing=west": { "model": "environmental:block/potted_cartwheel", "y": 270 }
     }
 }


### PR DESCRIPTION
Fixed two bugs here as well:
1) Removed a redundant axe stripping sound from WaxedPineconeBlock, as AxeItem already covers playing that sound depending on the inputted toolaction (and is still audible in testing, now at the same volume as when stripping normal logs)
2) Allowed Potted Cartwheels to be rotated like their block suggests.
- This one's might be a bit more controversial because vanilla lighting forces cartwheels to be a little more darkened in their east/west facing states. could possibly be improved with some culling stuff--I was never particularly good at block model management. That said, at least the functionality for cardinal cartwheel pot placement is now there 👍

And an accidental extra, because I didn't know git pushes on forks automatically add them to PR's retroactively 😓 
3) Added `forge:stripped_logs` block tag. I wholly understand why this wouldn't be considered (as Forge did not include it in its own canon), but I guess it's here if it wants to see some use.